### PR TITLE
configure default format to be JSON in Bootstrap class

### DIFF
--- a/src/JsonApiBootstrap.php
+++ b/src/JsonApiBootstrap.php
@@ -24,6 +24,7 @@ class JsonApiBootstrap implements BootstrapInterface
 
         $app->set('response', [
             'class' => Response::class,
+            'format' => \yii\web\Response::FORMAT_JSON,
             'formatters'=>[
                 \yii\web\Response::FORMAT_JSON => [
                     'class'=>JsonApiResponseFormatter::class,


### PR DESCRIPTION
without it returning array from an action will result in error.